### PR TITLE
compatible with multiple slurmd mode

### DIFF
--- a/cgroup_exporter.go
+++ b/cgroup_exporter.go
@@ -191,7 +191,9 @@ func getInfo(name string, metric *CgroupMetric, logger log.Logger) {
 				} */
 		return
 	}
-	slurmPattern := regexp.MustCompile("^/slurm/uid_([0-9]+)/job_([0-9]+)(/step_([^/]+)(/task_([[0-9]+))?)?$")
+	// slurmPattern := regexp.MustCompile("^/slurm/uid_([0-9]+)/job_([0-9]+)(/step_([^/]+)(/task_([[0-9]+))?)?$")
+	slurmPattern := regexp.MustCompile(`^/(?:slurm|slurm_[^/]+)/uid_([0-9]+)/job_([0-9]+)(/step_([^/]+)(/task_([[0-9]+))?)?$`)
+
 	slurmMatch := slurmPattern.FindStringSubmatch(name)
 	level.Debug(logger).Log("msg", "Got for match", "name", name, "len(slurmMatch)", len(slurmMatch), "slurmMatch", fmt.Sprintf("%v", slurmMatch))
 	if len(slurmMatch) >= 3 {


### PR DESCRIPTION
When multiple slurmd mode enabled, cgroup namespace  hierarchy is just like

```
/slurm_${nodename}/uid_${uid}/job_${jobid}/step_${step}/task_${task}/xxx
```

See slurm cgroup plugin source code as follows:

https://github.com/SchedMD/slurm/blob/master/src/plugins/cgroup/v1/xcgroup.c#L365

I think we should be compatible with this.

I've built a new version upon the pr and deployed on our production slurm cluster, it tested ok.